### PR TITLE
default response is not required, see 

### DIFF
--- a/src/V30/Hydrator/ResponsesHydrator.php
+++ b/src/V30/Hydrator/ResponsesHydrator.php
@@ -42,7 +42,9 @@ class ResponsesHydrator implements HydratorInterface
      */
     public function hydrate(array $data, $object)
     {
-        $object->setDefault(isset($data['default']['$ref'])? $this->referenceHydrator->hydrate($data['default'], new Reference()): $this->responseHydrator->hydrate($data['default'], new Response()));
+        if(isset($data['default'])){
+            $object->setDefault(isset($data['default']['$ref'])? $this->referenceHydrator->hydrate($data['default'] , new Reference()): $this->responseHydrator->hydrate($data['default'], new Response()));
+        }
 
         foreach ($data as $statusCode => $response) {
             if ($statusCode >= 100 && $statusCode <= 599) {


### PR DESCRIPTION
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#responsesObject

The default MAY be used as a default response object for all HTTP codes that are not covered individually by the specification.